### PR TITLE
Define festival and work tracking schema

### DIFF
--- a/app/Models/Festival.php
+++ b/app/Models/Festival.php
@@ -6,5 +6,18 @@ use Illuminate\Database\Eloquent\Model;
 
 class Festival extends Model
 {
-    //
+    protected $fillable = [
+        'name',
+        'year',
+    ];
+
+    public function phases()
+    {
+        return $this->hasMany(Phase::class);
+    }
+
+    public function participants()
+    {
+        return $this->hasMany(Participant::class);
+    }
 }

--- a/app/Models/Participant.php
+++ b/app/Models/Participant.php
@@ -6,5 +6,27 @@ use Illuminate\Database\Eloquent\Model;
 
 class Participant extends Model
 {
-    //
+    protected $fillable = [
+        'user_id',
+        'festival_id',
+        'tshirt_size',
+        'needs_car_ticket',
+        'arrival_date',
+        'departure_date',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function festival()
+    {
+        return $this->belongsTo(Festival::class);
+    }
+
+    public function workEntries()
+    {
+        return $this->hasMany(WorkEntry::class);
+    }
 }

--- a/app/Models/Phase.php
+++ b/app/Models/Phase.php
@@ -6,5 +6,20 @@ use Illuminate\Database\Eloquent\Model;
 
 class Phase extends Model
 {
-    //
+    protected $fillable = [
+        'festival_id',
+        'name',
+        'start_date',
+        'end_date',
+    ];
+
+    public function festival()
+    {
+        return $this->belongsTo(Festival::class);
+    }
+
+    public function workEntries()
+    {
+        return $this->hasMany(WorkEntry::class);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -45,4 +45,14 @@ class User extends Authenticatable
             'password' => 'hashed',
         ];
     }
+
+    public function participants()
+    {
+        return $this->hasMany(Participant::class);
+    }
+
+    public function workEntries()
+    {
+        return $this->hasManyThrough(WorkEntry::class, Participant::class);
+    }
 }

--- a/app/Models/WorkEntry.php
+++ b/app/Models/WorkEntry.php
@@ -6,5 +6,22 @@ use Illuminate\Database\Eloquent\Model;
 
 class WorkEntry extends Model
 {
-    //
+    protected $fillable = [
+        'participant_id',
+        'phase_id',
+        'work_date',
+        'duration',
+        'checked',
+        'recorded',
+    ];
+
+    public function participant()
+    {
+        return $this->belongsTo(Participant::class);
+    }
+
+    public function phase()
+    {
+        return $this->belongsTo(Phase::class);
+    }
 }

--- a/database/migrations/2025_08_09_184443_create_festivals_table.php
+++ b/database/migrations/2025_08_09_184443_create_festivals_table.php
@@ -13,6 +13,8 @@ return new class extends Migration
     {
         Schema::create('festivals', function (Blueprint $table) {
             $table->id();
+            $table->string('name');
+            $table->unsignedSmallInteger('year');
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_08_09_184443_create_phases_table.php
+++ b/database/migrations/2025_08_09_184443_create_phases_table.php
@@ -13,6 +13,10 @@ return new class extends Migration
     {
         Schema::create('phases', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('festival_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->date('start_date');
+            $table->date('end_date');
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_08_09_184444_create_participants_table.php
+++ b/database/migrations/2025_08_09_184444_create_participants_table.php
@@ -13,6 +13,12 @@ return new class extends Migration
     {
         Schema::create('participants', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('festival_id')->constrained()->cascadeOnDelete();
+            $table->string('tshirt_size')->nullable();
+            $table->boolean('needs_car_ticket')->default(false);
+            $table->date('arrival_date')->nullable();
+            $table->date('departure_date')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_08_09_184447_create_work_entries_table.php
+++ b/database/migrations/2025_08_09_184447_create_work_entries_table.php
@@ -13,6 +13,12 @@ return new class extends Migration
     {
         Schema::create('work_entries', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('participant_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('phase_id')->constrained()->cascadeOnDelete();
+            $table->date('work_date');
+            $table->decimal('duration', 3, 1);
+            $table->boolean('checked')->default(false);
+            $table->boolean('recorded')->default(false);
             $table->timestamps();
         });
     }


### PR DESCRIPTION
## Summary
- flesh out festival, phase, participant and work entry migrations
- add Eloquent models and relations for tracking crew participation
- expose participant and work entry relations on User

## Testing
- `php -l database/migrations/2025_08_09_184443_create_festivals_table.php database/migrations/2025_08_09_184443_create_phases_table.php database/migrations/2025_08_09_184444_create_participants_table.php database/migrations/2025_08_09_184447_create_work_entries_table.php app/Models/Festival.php app/Models/Phase.php app/Models/Participant.php app/Models/WorkEntry.php app/Models/User.php`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_6897a04131f4832dac9ff2968fae0240