### PR TITLE
Add auth provider and policy scaffolding

### DIFF
--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class UserPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, User $model): bool
+    {
+        return $user->id === $model->id;
+    }
+}
+

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Providers;
+
+use App\Models\User;
+use App\Policies\UserPolicy;
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    /**
+     * The model to policy mappings for the application.
+     *
+     * @var array<class-string, class-string>
+     */
+    protected $policies = [
+        User::class => UserPolicy::class,
+    ];
+
+    /**
+     * Register any authentication / authorization services.
+     */
+    public function boot(): void
+    {
+        $this->registerPolicies();
+    }
+}
+

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,8 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use App\Providers\AppServiceProvider;
+use App\Providers\AuthServiceProvider;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -15,4 +17,9 @@ return Application::configure(basePath: dirname(__DIR__))
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //
-    })->create();
+    })
+    ->withProviders([
+        AppServiceProvider::class,
+        AuthServiceProvider::class,
+    ])
+    ->create();


### PR DESCRIPTION
## Summary
- register service providers in bootstrap/app.php and enable auth service provider
- add AuthServiceProvider with User policy mapping
- stub UserPolicy for future authorization logic

## Testing
- `composer install` *(fails: GitHub authentication required)*
- `composer test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_6897df469398832d94643e1bd4dda4d9