### PR TITLE
Add work entry controller and views

### DIFF
--- a/app/Http/Controllers/WorkEntryController.php
+++ b/app/Http/Controllers/WorkEntryController.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\WorkEntry;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class WorkEntryController extends Controller
+{
+    /**
+     * Show form to create a new work entry.
+     */
+    public function create(): View
+    {
+        $participant = Auth::user()->participants()->first();
+
+        return view('work_entries.create', [
+            'participant' => $participant,
+        ]);
+    }
+
+    /**
+     * Persist a new work entry.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $participant = Auth::user()->participants()->first();
+        $validated = $this->validateEntry($request);
+
+        if ($participant) {
+            $participant->update([
+                'tshirt_size' => $validated['tshirt_size'],
+                'needs_car_ticket' => $validated['needs_car_ticket'] ?? false,
+                'arrival_date' => $validated['arrival_date'] ?? null,
+                'departure_date' => $validated['departure_date'] ?? null,
+            ]);
+
+            $participant->workEntries()->create([
+                'phase_id' => $request->input('phase_id', 1),
+                'work_date' => $validated['work_date'],
+                'duration' => $validated['duration'],
+            ]);
+        }
+
+        return redirect()->route('work-entries.create')->with('status', 'work-entry-created');
+    }
+
+    /**
+     * Show the form for editing a work entry.
+     */
+    public function edit(WorkEntry $workEntry): View
+    {
+        $participant = Auth::user()->participants()->first();
+
+        return view('work_entries.edit', [
+            'participant' => $participant,
+            'workEntry' => $workEntry,
+        ]);
+    }
+
+    /**
+     * Update an existing work entry.
+     */
+    public function update(Request $request, WorkEntry $workEntry): RedirectResponse
+    {
+        $participant = Auth::user()->participants()->first();
+        $validated = $this->validateEntry($request);
+
+        if ($participant) {
+            $participant->update([
+                'tshirt_size' => $validated['tshirt_size'],
+                'needs_car_ticket' => $validated['needs_car_ticket'] ?? false,
+                'arrival_date' => $validated['arrival_date'] ?? null,
+                'departure_date' => $validated['departure_date'] ?? null,
+            ]);
+        }
+
+        $workEntry->update([
+            'work_date' => $validated['work_date'],
+            'duration' => $validated['duration'],
+        ]);
+
+        return redirect()->route('work-entries.edit', $workEntry)->with('status', 'work-entry-updated');
+    }
+
+    /**
+     * Validate common fields.
+     */
+    protected function validateEntry(Request $request): array
+    {
+        return $request->validate([
+            'work_date' => ['required', 'date'],
+            'duration' => ['required', 'numeric', 'in:0.5,1,1.5,2'],
+            'tshirt_size' => ['required', 'in:XS,S,M,L,XL,XXL'],
+            'needs_car_ticket' => ['sometimes', 'boolean'],
+            'arrival_date' => ['nullable', 'date'],
+            'departure_date' => ['nullable', 'date', 'after_or_equal:arrival_date'],
+        ]);
+    }
+}

--- a/resources/views/work_entries/create.blade.php
+++ b/resources/views/work_entries/create.blade.php
@@ -1,0 +1,66 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Add Work Day') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <form method="POST" action="{{ route('work-entries.store') }}">
+                        @csrf
+
+                        <div>
+                            <x-input-label for="work_date" :value="__('Date')" />
+                            <x-text-input id="work_date" class="block mt-1 w-full" type="date" name="work_date" :value="old('work_date')" required />
+                            <x-input-error :messages="$errors->get('work_date')" class="mt-2" />
+                        </div>
+
+                        <div class="mt-4">
+                            <x-input-label for="duration" :value="__('Duration (days)')" />
+                            <x-text-input id="duration" class="block mt-1 w-full" type="number" step="0.5" min="0.5" max="2" name="duration" :value="old('duration')" required />
+                            <x-input-error :messages="$errors->get('duration')" class="mt-2" />
+                        </div>
+
+                        <div class="mt-4">
+                            <x-input-label for="tshirt_size" :value="__('T-Shirt Size')" />
+                            <select id="tshirt_size" name="tshirt_size" class="block mt-1 w-full" required>
+                                <option value="">--</option>
+                                @foreach(['XS','S','M','L','XL','XXL'] as $size)
+                                    <option value="{{ $size }}" @selected(old('tshirt_size', optional($participant)->tshirt_size) == $size)>{{ $size }}</option>
+                                @endforeach
+                            </select>
+                            <x-input-error :messages="$errors->get('tshirt_size')" class="mt-2" />
+                        </div>
+
+                        <div class="mt-4">
+                            <label class="flex items-center">
+                                <input type="checkbox" name="needs_car_ticket" value="1" @checked(old('needs_car_ticket', optional($participant)->needs_car_ticket))>
+                                <span class="ml-2">{{ __('Need Car Ticket') }}</span>
+                            </label>
+                            <x-input-error :messages="$errors->get('needs_car_ticket')" class="mt-2" />
+                        </div>
+
+                        <div class="mt-4">
+                            <x-input-label for="arrival_date" :value="__('Arrival Date')" />
+                            <x-text-input id="arrival_date" class="block mt-1 w-full" type="date" name="arrival_date" :value="old('arrival_date', optional($participant)->arrival_date)" />
+                            <x-input-error :messages="$errors->get('arrival_date')" class="mt-2" />
+                        </div>
+
+                        <div class="mt-4">
+                            <x-input-label for="departure_date" :value="__('Departure Date')" />
+                            <x-text-input id="departure_date" class="block mt-1 w-full" type="date" name="departure_date" :value="old('departure_date', optional($participant)->departure_date)" />
+                            <x-input-error :messages="$errors->get('departure_date')" class="mt-2" />
+                        </div>
+
+                        <div class="flex items-center justify-end mt-4">
+                            <x-primary-button>{{ __('Save') }}</x-primary-button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/work_entries/edit.blade.php
+++ b/resources/views/work_entries/edit.blade.php
@@ -1,0 +1,67 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Edit Work Day') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <form method="POST" action="{{ route('work-entries.update', $workEntry) }}">
+                        @csrf
+                        @method('PUT')
+
+                        <div>
+                            <x-input-label for="work_date" :value="__('Date')" />
+                            <x-text-input id="work_date" class="block mt-1 w-full" type="date" name="work_date" :value="old('work_date', $workEntry->work_date)" required />
+                            <x-input-error :messages="$errors->get('work_date')" class="mt-2" />
+                        </div>
+
+                        <div class="mt-4">
+                            <x-input-label for="duration" :value="__('Duration (days)')" />
+                            <x-text-input id="duration" class="block mt-1 w-full" type="number" step="0.5" min="0.5" max="2" name="duration" :value="old('duration', $workEntry->duration)" required />
+                            <x-input-error :messages="$errors->get('duration')" class="mt-2" />
+                        </div>
+
+                        <div class="mt-4">
+                            <x-input-label for="tshirt_size" :value="__('T-Shirt Size')" />
+                            <select id="tshirt_size" name="tshirt_size" class="block mt-1 w-full" required>
+                                <option value="">--</option>
+                                @foreach(['XS','S','M','L','XL','XXL'] as $size)
+                                    <option value="{{ $size }}" @selected(old('tshirt_size', optional($participant)->tshirt_size) == $size)>{{ $size }}</option>
+                                @endforeach
+                            </select>
+                            <x-input-error :messages="$errors->get('tshirt_size')" class="mt-2" />
+                        </div>
+
+                        <div class="mt-4">
+                            <label class="flex items-center">
+                                <input type="checkbox" name="needs_car_ticket" value="1" @checked(old('needs_car_ticket', optional($participant)->needs_car_ticket))>
+                                <span class="ml-2">{{ __('Need Car Ticket') }}</span>
+                            </label>
+                            <x-input-error :messages="$errors->get('needs_car_ticket')" class="mt-2" />
+                        </div>
+
+                        <div class="mt-4">
+                            <x-input-label for="arrival_date" :value="__('Arrival Date')" />
+                            <x-text-input id="arrival_date" class="block mt-1 w-full" type="date" name="arrival_date" :value="old('arrival_date', optional($participant)->arrival_date)" />
+                            <x-input-error :messages="$errors->get('arrival_date')" class="mt-2" />
+                        </div>
+
+                        <div class="mt-4">
+                            <x-input-label for="departure_date" :value="__('Departure Date')" />
+                            <x-text-input id="departure_date" class="block mt-1 w-full" type="date" name="departure_date" :value="old('departure_date', optional($participant)->departure_date)" />
+                            <x-input-error :messages="$errors->get('departure_date')" class="mt-2" />
+                        </div>
+
+                        <div class="flex items-center justify-end mt-4">
+                            <x-primary-button>{{ __('Update') }}</x-primary-button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\WorkEntryController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -15,6 +16,10 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+
+    Route::resource('work-entries', WorkEntryController::class)->only([
+        'create', 'store', 'edit', 'update',
+    ]);
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- add WorkEntryController with create, store, edit and update actions
- create Blade views for creating and editing work days
- wire up routes and validation for date, duration, shirt size and travel details

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_6897df652edc832daa3f3bf541512900