### PR TITLE
Add admin controllers, views, and access control

### DIFF
--- a/app/Http/Controllers/Admin/FestivalController.php
+++ b/app/Http/Controllers/Admin/FestivalController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Festival;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class FestivalController extends Controller
+{
+    public function index(): View
+    {
+        $festivals = Festival::all();
+
+        return view('admin.festivals.index', compact('festivals'));
+    }
+
+    public function create(): View
+    {
+        return view('admin.festivals.create');
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string'],
+            'year' => ['required', 'integer'],
+        ]);
+
+        Festival::create($data);
+
+        return redirect()->route('admin.festivals.index');
+    }
+
+    public function show(Festival $festival): View
+    {
+        return view('admin.festivals.show', compact('festival'));
+    }
+
+    public function edit(Festival $festival): View
+    {
+        return view('admin.festivals.edit', compact('festival'));
+    }
+
+    public function update(Request $request, Festival $festival): RedirectResponse
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string'],
+            'year' => ['required', 'integer'],
+        ]);
+
+        $festival->update($data);
+
+        return redirect()->route('admin.festivals.index');
+    }
+
+    public function destroy(Festival $festival): RedirectResponse
+    {
+        $festival->delete();
+
+        return redirect()->route('admin.festivals.index');
+    }
+}

--- a/app/Http/Controllers/Admin/PhaseController.php
+++ b/app/Http/Controllers/Admin/PhaseController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Festival;
+use App\Models\Phase;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class PhaseController extends Controller
+{
+    public function index(): View
+    {
+        $phases = Phase::with('festival')->get();
+
+        return view('admin.phases.index', compact('phases'));
+    }
+
+    public function create(): View
+    {
+        $festivals = Festival::all();
+
+        return view('admin.phases.create', compact('festivals'));
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'festival_id' => ['required', 'exists:festivals,id'],
+            'name' => ['required', 'string'],
+            'start_date' => ['required', 'date'],
+            'end_date' => ['required', 'date'],
+        ]);
+
+        Phase::create($data);
+
+        return redirect()->route('admin.phases.index');
+    }
+
+    public function show(Phase $phase): View
+    {
+        return view('admin.phases.show', compact('phase'));
+    }
+
+    public function edit(Phase $phase): View
+    {
+        $festivals = Festival::all();
+
+        return view('admin.phases.edit', compact('phase', 'festivals'));
+    }
+
+    public function update(Request $request, Phase $phase): RedirectResponse
+    {
+        $data = $request->validate([
+            'festival_id' => ['required', 'exists:festivals,id'],
+            'name' => ['required', 'string'],
+            'start_date' => ['required', 'date'],
+            'end_date' => ['required', 'date'],
+        ]);
+
+        $phase->update($data);
+
+        return redirect()->route('admin.phases.index');
+    }
+
+    public function destroy(Phase $phase): RedirectResponse
+    {
+        $phase->delete();
+
+        return redirect()->route('admin.phases.index');
+    }
+}

--- a/app/Http/Middleware/EnsureAdmin.php
+++ b/app/Http/Middleware/EnsureAdmin.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureAdmin
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! $request->user() || ! $request->user()->is_admin) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,6 +21,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'is_admin',
     ];
 
     /**
@@ -43,6 +44,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'is_admin' => 'boolean',
         ];
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Gate;
+use App\Models\User;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +21,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Gate::define('admin', function (User $user): bool {
+            return (bool) $user->is_admin;
+        });
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'admin' => \App\Http\Middleware\EnsureAdmin::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/database/migrations/2025_08_09_184448_add_is_admin_to_users_table.php
+++ b/database/migrations/2025_08_09_184448_add_is_admin_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_admin')->default(false)->after('password');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_admin');
+        });
+    }
+};

--- a/resources/views/admin/festivals/create.blade.php
+++ b/resources/views/admin/festivals/create.blade.php
@@ -1,0 +1,24 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Create Festival') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <form method="POST" action="{{ route('admin.festivals.store') }}" class="bg-white p-6 rounded shadow">
+                @csrf
+                <div class="mb-4">
+                    <label class="block">{{ __('Name') }}</label>
+                    <input type="text" name="name" value="{{ old('name') }}" class="border rounded w-full" />
+                </div>
+                <div class="mb-4">
+                    <label class="block">{{ __('Year') }}</label>
+                    <input type="number" name="year" value="{{ old('year') }}" class="border rounded w-full" />
+                </div>
+                <x-primary-button>{{ __('Save') }}</x-primary-button>
+            </form>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/festivals/edit.blade.php
+++ b/resources/views/admin/festivals/edit.blade.php
@@ -1,0 +1,25 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Edit Festival') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <form method="POST" action="{{ route('admin.festivals.update', $festival) }}" class="bg-white p-6 rounded shadow">
+                @csrf
+                @method('PUT')
+                <div class="mb-4">
+                    <label class="block">{{ __('Name') }}</label>
+                    <input type="text" name="name" value="{{ old('name', $festival->name) }}" class="border rounded w-full" />
+                </div>
+                <div class="mb-4">
+                    <label class="block">{{ __('Year') }}</label>
+                    <input type="number" name="year" value="{{ old('year', $festival->year) }}" class="border rounded w-full" />
+                </div>
+                <x-primary-button>{{ __('Update') }}</x-primary-button>
+            </form>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/festivals/index.blade.php
+++ b/resources/views/admin/festivals/index.blade.php
@@ -1,0 +1,30 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Festivals') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="mb-4">
+                <a href="{{ route('admin.festivals.create') }}" class="text-blue-500">{{ __('Create Festival') }}</a>
+            </div>
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <ul>
+                    @foreach($festivals as $festival)
+                        <li class="p-6 border-b">
+                            <a href="{{ route('admin.festivals.show', $festival) }}" class="text-indigo-600">{{ $festival->name }} ({{ $festival->year }})</a>
+                            <a href="{{ route('admin.festivals.edit', $festival) }}" class="ml-4 text-blue-600">{{ __('Edit') }}</a>
+                            <form action="{{ route('admin.festivals.destroy', $festival) }}" method="POST" class="inline-block ml-4">
+                                @csrf
+                                @method('DELETE')
+                                <button class="text-red-600" onclick="return confirm('Are you sure?')">{{ __('Delete') }}</button>
+                            </form>
+                        </li>
+                    @endforeach
+                </ul>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/festivals/show.blade.php
+++ b/resources/views/admin/festivals/show.blade.php
@@ -1,0 +1,15 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ $festival->name }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white p-6 rounded shadow">
+                <p>{{ __('Year') }}: {{ $festival->year }}</p>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/phases/create.blade.php
+++ b/resources/views/admin/phases/create.blade.php
@@ -1,0 +1,36 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Create Phase') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <form method="POST" action="{{ route('admin.phases.store') }}" class="bg-white p-6 rounded shadow">
+                @csrf
+                <div class="mb-4">
+                    <label class="block">{{ __('Festival') }}</label>
+                    <select name="festival_id" class="border rounded w-full">
+                        @foreach($festivals as $festival)
+                            <option value="{{ $festival->id }}">{{ $festival->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="mb-4">
+                    <label class="block">{{ __('Name') }}</label>
+                    <input type="text" name="name" value="{{ old('name') }}" class="border rounded w-full" />
+                </div>
+                <div class="mb-4">
+                    <label class="block">{{ __('Start Date') }}</label>
+                    <input type="date" name="start_date" value="{{ old('start_date') }}" class="border rounded w-full" />
+                </div>
+                <div class="mb-4">
+                    <label class="block">{{ __('End Date') }}</label>
+                    <input type="date" name="end_date" value="{{ old('end_date') }}" class="border rounded w-full" />
+                </div>
+                <x-primary-button>{{ __('Save') }}</x-primary-button>
+            </form>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/phases/edit.blade.php
+++ b/resources/views/admin/phases/edit.blade.php
@@ -1,0 +1,37 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Edit Phase') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <form method="POST" action="{{ route('admin.phases.update', $phase) }}" class="bg-white p-6 rounded shadow">
+                @csrf
+                @method('PUT')
+                <div class="mb-4">
+                    <label class="block">{{ __('Festival') }}</label>
+                    <select name="festival_id" class="border rounded w-full">
+                        @foreach($festivals as $festival)
+                            <option value="{{ $festival->id }}" @selected(old('festival_id', $phase->festival_id) == $festival->id)>{{ $festival->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="mb-4">
+                    <label class="block">{{ __('Name') }}</label>
+                    <input type="text" name="name" value="{{ old('name', $phase->name) }}" class="border rounded w-full" />
+                </div>
+                <div class="mb-4">
+                    <label class="block">{{ __('Start Date') }}</label>
+                    <input type="date" name="start_date" value="{{ old('start_date', $phase->start_date) }}" class="border rounded w-full" />
+                </div>
+                <div class="mb-4">
+                    <label class="block">{{ __('End Date') }}</label>
+                    <input type="date" name="end_date" value="{{ old('end_date', $phase->end_date) }}" class="border rounded w-full" />
+                </div>
+                <x-primary-button>{{ __('Update') }}</x-primary-button>
+            </form>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/phases/index.blade.php
+++ b/resources/views/admin/phases/index.blade.php
@@ -1,0 +1,31 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Phases') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="mb-4">
+                <a href="{{ route('admin.phases.create') }}" class="text-blue-500">{{ __('Create Phase') }}</a>
+            </div>
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <ul>
+                    @foreach($phases as $phase)
+                        <li class="p-6 border-b">
+                            <a href="{{ route('admin.phases.show', $phase) }}" class="text-indigo-600">{{ $phase->name }}</a>
+                            <span class="ml-2 text-gray-600">({{ $phase->festival->name }})</span>
+                            <a href="{{ route('admin.phases.edit', $phase) }}" class="ml-4 text-blue-600">{{ __('Edit') }}</a>
+                            <form action="{{ route('admin.phases.destroy', $phase) }}" method="POST" class="inline-block ml-4">
+                                @csrf
+                                @method('DELETE')
+                                <button class="text-red-600" onclick="return confirm('Are you sure?')">{{ __('Delete') }}</button>
+                            </form>
+                        </li>
+                    @endforeach
+                </ul>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/phases/show.blade.php
+++ b/resources/views/admin/phases/show.blade.php
@@ -1,0 +1,17 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ $phase->name }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white p-6 rounded shadow">
+                <p>{{ __('Festival') }}: {{ $phase->festival->name }}</p>
+                <p>{{ __('Start Date') }}: {{ $phase->start_date }}</p>
+                <p>{{ __('End Date') }}: {{ $phase->end_date }}</p>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\Admin\FestivalController as AdminFestivalController;
+use App\Http\Controllers\Admin\PhaseController as AdminPhaseController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -15,6 +17,11 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+});
+
+Route::middleware(['auth', 'admin'])->prefix('admin')->name('admin.')->group(function () {
+    Route::resource('festivals', AdminFestivalController::class);
+    Route::resource('phases', AdminPhaseController::class);
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- add admin resource controllers for festivals and phases
- build CRUD blade views for festivals and phases
- implement admin middleware with `is_admin` flag for access control

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_6897df66ead8832d8ff2f8ffb84b73f3