### PR TITLE
Add work entry overview with grouped summaries

### DIFF
--- a/app/Http/Controllers/WorkEntryController.php
+++ b/app/Http/Controllers/WorkEntryController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\WorkEntry;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class WorkEntryController extends Controller
+{
+    /**
+     * Display a listing of the work entries grouped by date and participant.
+     *
+     * @param  Request  $request
+     */
+    public function index(Request $request): View
+    {
+        $start = $request->query('start');
+        $end = $request->query('end');
+
+        $entriesByDate = WorkEntry::with('participant.user')
+            ->forDateRange($start, $end)
+            ->groupedByDateAndParticipant()
+            ->get()
+            ->groupBy('work_date');
+
+        $totalDuration = WorkEntry::forDateRange($start, $end)->sum('duration');
+
+        return view('work_entries.index', [
+            'entriesByDate' => $entriesByDate,
+            'totalDuration' => $totalDuration,
+            'start' => $start,
+            'end' => $end,
+        ]);
+    }
+}
+

--- a/app/Models/WorkEntry.php
+++ b/app/Models/WorkEntry.php
@@ -2,7 +2,9 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
 
 class WorkEntry extends Model
 {
@@ -23,5 +25,34 @@ class WorkEntry extends Model
     public function phase()
     {
         return $this->belongsTo(Phase::class);
+    }
+
+    /**
+     * Scope a query to only include entries within the given date range.
+     *
+     * @param  string|null  $start
+     * @param  string|null  $end
+     */
+    public function scopeForDateRange(Builder $query, ?string $start = null, ?string $end = null): Builder
+    {
+        if ($start) {
+            $query->whereDate('work_date', '>=', $start);
+        }
+
+        if ($end) {
+            $query->whereDate('work_date', '<=', $end);
+        }
+
+        return $query;
+    }
+
+    /**
+     * Scope a query to aggregate durations grouped by date and participant.
+     */
+    public function scopeGroupedByDateAndParticipant(Builder $query): Builder
+    {
+        return $query
+            ->select('participant_id', 'work_date', DB::raw('SUM(duration) as total_duration'))
+            ->groupBy('participant_id', 'work_date');
     }
 }

--- a/resources/views/work_entries/index.blade.php
+++ b/resources/views/work_entries/index.blade.php
@@ -1,0 +1,35 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Work Entries') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900">
+                    <p>{{ __('Total Duration: :hours h', ['hours' => $totalDuration]) }}</p>
+
+                    @foreach($entriesByDate as $date => $entries)
+                        <div class="mt-4">
+                            <h3 class="font-semibold">
+                                {{ \Illuminate\Support\Carbon::parse($date)->toFormattedDateString() }}
+                                ({{ $entries->sum('total_duration') }}h)
+                            </h3>
+                            <ul class="ml-4 list-disc">
+                                @foreach($entries as $entry)
+                                    <li>
+                                        {{ optional($entry->participant->user)->name
+                                            ?? __('Participant #:id', ['id' => $entry->participant_id]) }}:
+                                        {{ $entry->total_duration }}h
+                                    </li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\WorkEntryController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -15,6 +16,8 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+
+    Route::get('/work-entries', [WorkEntryController::class, 'index'])->name('work-entries.index');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- add scopes on WorkEntry for date ranges and grouped duration sums
- add WorkEntryController with daily/participant summary and type hints
- add work entry list view and route with totals

## Testing
- `composer install --no-interaction --no-progress` *(failed: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(command not found: phpunit)*
- `php -l app/Http/Controllers/WorkEntryController.php app/Models/WorkEntry.php routes/web.php`


------
https://chatgpt.com/codex/tasks/task_e_6897df660f54832d8c38127403c92027